### PR TITLE
Displaying default values in '--help'

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,7 +9,7 @@ const NL = '\n';
 function format(arr) {
 	if (!arr.length) return '';
 	let len = maxLen( arr.map(x => x[0]) ) + GAP;
-	let join = a => rpad(a[0], len, ' ') + a[1] + (a[2] == null ? '' : `  (default ${a[2]})`);
+	let join = a => rpad(a[0], len, ' ') + a[1] + (a[2] == null ? '' : `  (default ${JSON.stringify(a[2])})`);
 	return arr.map(join);
 }
 


### PR DESCRIPTION
First, great work on this! Just implemented it on a project of mine and it's awesome. :+1: 

I noticed that, when using default values for my command options, they don't always display properly in the help output. Example:

![sade-options-default](https://user-images.githubusercontent.com/3484188/34927227-4792006e-f97a-11e7-9952-4dd9ddbe85f7.png)

-e has a default value of empty string (`""`)
-f has a default value of empty array (`[]`)

Dug through the code for a few minutes, and came up with a few ideas based on my limited understanding:

1. Could `JSON.stringify()` the value when outputting it here. If I'm correct, stringifying something isn't the fastest operation, so that may or may not be the best option.
2. Could add a fourth parameter to `.option()` that accepts a display value for the help text. My other use case for that would be when the default value is something like `process.cwd()` - I wouldn't want to display the current working directory, just something like "." or "cwd". I don't necessarily think it's worth adding another parameter just for this one small case, though.

I opened this PR for possible solutions. If you're not worried about it, or we can't come up with a solution in line with your goals for the project, then feel free to close this! It's a pretty minor thing.

Thanks!
 