### PR TITLE
Allow inner hyphens in options

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -80,7 +80,7 @@ exports.error = function (bin, str, num=1) {
 }
 
 exports.parse = function (str) {
-	return (str || '').replace(/-{1,2}/g, '').split(/,?\s+/);
+	return (str || '').replace(/(^|\s)-{1,2}/g, '').split(/,|,?\s+/);
 }
 
 // @see https://stackoverflow.com/a/18914855/3577474

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -79,8 +79,9 @@ exports.error = function (bin, str, num=1) {
 	process.exit(num);
 }
 
+// Strips leading `-|--` & extra space(s)
 exports.parse = function (str) {
-	return (str || '').replace(/(^|\s)-{1,2}/g, '').split(/,|,?\s+/);
+	return (str || '').replace(/(^|\s+)-{1,2}/g, '').split(/,|\s+/).filter(Boolean);
 }
 
 // @see https://stackoverflow.com/a/18914855/3577474

--- a/test/index.js
+++ b/test/index.js
@@ -137,7 +137,7 @@ test('prog.command', t => {
 	t.end();
 });
 
-test.only('prog.action', t => {
+test('prog.action', t => {
 	t.plan(13);
 	let a='Bob', b, c, d, e;
 

--- a/test/index.js
+++ b/test/index.js
@@ -49,6 +49,9 @@ test('prog.option (global)', t => {
 	t.ok(Array.isArray(item), 'options entry is also an array');
 	t.is(item.length, 3, 'entry has 3 segments (flags, desc, default)');
 	t.is(item[0], '-f, --foo', 'flips the flags order; alias is first');
+	ctx.option('-w, --with-hyphen');
+	let hyphenatedItem = arr[1];
+	t.is(hyphenatedItem[0], '-w, --with-hyphen', 'keeps inner hyphens intact');
 	t.end();
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -137,9 +137,9 @@ test('prog.command', t => {
 	t.end();
 });
 
-test('prog.action', t => {
-	t.plan(11);
-	let a='Bob', b, c, d;
+test.only('prog.action', t => {
+	t.plan(13);
+	let a='Bob', b, c, d, e;
 
 	let ctx = sade('foo')
 		.command('greet <name>')
@@ -150,7 +150,8 @@ test('prog.action', t => {
 			b && t.ok(opts.loud, '~> receives the `loud` flag (true) when parsed');
 			c && t.ok(opts['with-kiss'], '~> receives the `with-kiss` flag (true) when parsed :: preserves mid-hyphen');
 			d && t.is(opts['with-kiss'], 'cheek', '~> receives the `with-kiss` flag (`cheek`) when parsed :: preserves mid-hyphen');
-			b = c = d = false; // reset
+			e && t.is(opts['with-kiss'], false, '~> receive the `--no-with-kiss` flag (false) :: preserves mid-hyphen');
+			b = c = d = e = false; // reset
 		});
 
 	// Simulate `process.argv` entry
@@ -165,6 +166,7 @@ test('prog.action', t => {
 	(c=true) && run('--with-kiss'); // +2 tests
 	(d=true) && run('--with-kiss=cheek'); // +2 tests
 	(d=true) && run(['--with-kiss', 'cheek']); // +2 tests
+	(e=true) && run('--no-with-kiss'); // +2 tests
 });
 
 test('prog.action (multi requires)', t => {


### PR DESCRIPTION
This update allows options to have inner hyphens, as highlighted in the issue referenced below. I'm not proud of my regex skills, so let me know if you have a better implementation idea or if I should add any more tests.

Closes #9 