### PR TITLE
feat: setType

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,8 @@ class Sade {
 		this.command(`${DEF} <command>`)
 			.option('-v, --version', 'Displays current version');
 		this.curr = ''; // reset
+		// enable parsing types for mri
+		this.types = {};
 	}
 
 	command(str, desc, opts) {
@@ -72,6 +74,11 @@ class Sade {
 		return this;
 	}
 
+	setType(types = { string: [], boolean: [] }) {
+		this.types = types;
+		return this;
+	}
+
 	action(handler) {
 		this.tree[ this.curr || DEF ].handler = handler;
 		return this;
@@ -90,7 +97,15 @@ class Sade {
 	parse(arr, opts={}) {
 		let offset = 2; // argv slicer
 		let alias = { h:'help', v:'version' };
-		let argv = mri(arr.slice(offset), { alias });
+		// apply types
+		const types = this.types;
+		const string = types.string || [];
+		const boolean = types.boolean || [];
+		let argv = mri(arr.slice(offset), {
+			alias,
+			string,
+			boolean
+		});
 		let bin = this.name;
 
 		// Loop thru possible command(s)
@@ -133,6 +148,9 @@ class Sade {
 		// merge all objects :: params > command > all
 		opts.alias = Object.assign(all.alias, cmd.alias, opts.alias);
 		opts.default = Object.assign(all.default, cmd.default, opts.default);
+		// apply types
+		opts.string = string;
+		opts.boolean = boolean;
 
 		let vals = mri(arr.slice(offset), opts);
 		let segs = cmd.usage.split(/\s+/);

--- a/readme.md
+++ b/readme.md
@@ -444,6 +444,28 @@ Default: `null`
 
 The name of the command for which to display help. Otherwise displays the general help.
 
+### prog.setType(opts)
+
+This allows you to set options' type explicitly. In fact, you can override the default type.
+
+#### opts
+
+Type: `Object`<br>
+Default: `{ string: [], boolean: [] }`
+
+For more details, checkout [mri API](registry=http://registry.npm.qiwoo.org) for `options.string` and `options.boolean` parts.
+
+```js
+prog
+  .setType({ boolean: ['flag1'] })
+  .command('test')
+  .option('--flag1', 'this is flag1', 'true')
+  .action(opts => {
+    console.log(typeof opts.flag1); // boolean
+  });
+
+prog.parse(['', '', 'test', '--flag1=false']);
+```
 
 ## License
 

--- a/test/index.js
+++ b/test/index.js
@@ -248,3 +248,20 @@ test('parse lazy', t => {
 
 	bar.handler.apply(null, bar.args); // manual bcuz lazy; +2 tests
 });
+
+test('explicitly parse boolean and string', t => {
+	t.plan(3);
+	const ctx = sade('foo')
+		.setType({ boolean: ['boolean'], string: ['string', 'booleanString'] })
+		.command('test')
+		.option('--boolean', 'this should be Boolean', true)
+		.option('--string', 'this should be String', null)
+		.option('--booleanString', 'this should be String', true)
+		.action(opts => {
+			t.is(opts.boolean, false, '~> boolean should be Boolean');
+			t.is(opts.string, 'false', '~> string should be String');
+			t.is(opts.booleanString, 'false', '~> booleanString should be String');
+		})
+	const run = _ => ctx.parse(['', '', 'test', '--boolean=false', '--string=false', '--booleanString=false']);
+	run();
+})


### PR DESCRIPTION
Allow users to set options' type explicitly.

Typical use case would be `--flag=true`.

And API looks like this

```js
prog.setType({ boolean: ['flag'] });
```

Some of us may want `typeof flag === 'string'`, while others may prefer `typeof flag === 'boolean'`.

An edge case would be when setting the default value to `null`, then `typeof flag` would always be `'string'`. But users should be able to make sure the type is always `boolean`.