### PR TITLE
feat: display subcommands as nested commands instead of as flat list of all commands

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,9 +52,14 @@ exports.help = function (bin, tree, key, single) {
 	out += section('Description', cmd.describe, noop);
 	out += section('Usage', [cmd.usage], prefix);
 
-	if (!single && key === DEF) {
+	if (!single) {
 		// General help :: print all non-internal commands & their 1st line of text
-		let cmds = Object.keys(tree).filter(k => !/__/.test(k));
+		const filter =
+			key === DEF
+				? k => !/(__| )/.test(k) // root command
+				// : k => new RegExp(`^${key} [\S\[\<]+$`).test(k); // subcommand
+				: k => k !== key && k.startsWith(key) && k.indexOf(' ', key.length + 1) === -1; // subcommand
+		let cmds = Object.keys(tree).filter(filter);
 		let text = cmds.map(k => [k, (tree[k].describe || [''])[0]]);
 		out += section('Available Commands', format(text), noop);
 

--- a/test/fixtures/subs.js
+++ b/test/fixtures/subs.js
@@ -17,4 +17,14 @@ sade('bin')
     console.log(`~> ran "remote rename" with "${old}" and "${nxt}" args`);
   })
 
+  .command('remote child')
+  .action((opts) => {
+    console.log(`~> ran "remote child" action`);
+  })
+
+  .command('remote child grandchild <arg>')
+  .action((arg, opts) => {
+    console.log(`~> ran "remote child grandchild" with "${arg}" arg`);
+  })
+
 	.parse(process.argv);

--- a/test/usage.js
+++ b/test/usage.js
@@ -261,7 +261,7 @@ test('(usage) subcommands', t => {
 test('(usage) subcommands :: help', t => {
 	let pid1 = exec('subs.js', ['--help']);
 	t.is(pid1.status, 0, 'exits without error code');
-	t.true(pid1.stdout.toString().includes('Available Commands\n    remote           \n    remote add       \n    remote rename'), '~> shows global help w/ "Available Commands" text');
+	t.true(pid1.stdout.toString().includes('Available Commands\n    remote'), '~> shows global help w/ "Available Commands" text');
 	t.is(pid1.stderr.length, 0, '~> stderr is empty');
 
 	let pid2 = exec('subs.js', ['remote', '--help']);
@@ -272,7 +272,19 @@ test('(usage) subcommands :: help', t => {
 	let pid3 = exec('subs.js', ['remote', 'rename', '--help']);
 	t.is(pid3.status, 0, 'exits without error code');
 	t.true(pid3.stdout.toString().includes('Usage\n    $ bin remote rename <old> <new> [options]'), '~> shows "remote rename" help text');
+	t.false(pid3.stdout.toString().includes('    $ bin remote child grandchild'), '~> does not show "remote child grandchild" help text');
 	t.is(pid3.stderr.length, 0, '~> stderr is empty');
+
+	let pid4 = exec('subs.js', ['remote', 'child', '--help']);
+	t.is(pid4.status, 0, 'exits without error code');
+	t.true(pid4.stdout.toString().includes('Usage\n    $ bin remote child [options]'), '~> shows "remote child" help text');
+	t.true(pid4.stdout.toString().includes('Available Commands\n    remote child grandchild    \n'), '~> only shows child commands of current command in help text');
+	t.is(pid4.stderr.length, 0, '~> stderr is empty');
+
+	let pid5 = exec('subs.js', ['remote', 'child', 'grandchild', '--help']);
+	t.is(pid5.status, 0, 'exits without error code');
+	t.true(pid5.stdout.toString().includes('Usage\n    $ bin remote child grandchild <arg> [options]'), '~> shows "remote child grandchild" help text');
+	t.is(pid5.stderr.length, 0, '~> stderr is empty');
 
 	t.end();
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -44,10 +44,10 @@ test('utils.help', t => {
 	t.is(foo, '\n  Description\n    global foo\n\n  Usage\n    $ foo <command> [options]\n\n  Available Commands\n    bar     Hello.\n    fizz    \n\n  For more info, run any command with the `--help` flag\n    $ foo bar --help\n    $ foo fizz --help\n\n  Options\n    -v, --version    Displays current version\n    -h, --help       Displays this message\n');
 
 	let bar = $.help(bin, tree, 'bar'); // two-line description
-	t.is(bar, '\n  Description\n    Hello.\n    World.\n\n  Usage\n    $ foo bar [options]\n\n  Options\n    -h, --help    Displays this message\n');
+	t.is(bar, '\n  Description\n    Hello.\n    World.\n\n  Usage\n    $ foo bar [options]\n\n  For more info, run any command with the `--help` flag\n\n  Options\n    -h, --help    Displays this message\n');
 
 	let fizz = $.help(bin, tree, 'fizz'); // no description
-	t.is(fizz, '\n  Usage\n    $ foo fizz <buzz> [options]\n\n  Options\n    -h, --help    Displays this message\n');
+	t.is(fizz, '\n  Usage\n    $ foo fizz <buzz> [options]\n\n  For more info, run any command with the `--help` flag\n\n  Options\n    -h, --help    Displays this message\n');
 
 	t.end();
 });


### PR DESCRIPTION
When creating complex or deeply nested commands, the previous behavior displayed a long flat list of all the commands, including all the subcommands at all nested levels.

For example, consider a program with the following list of commands:
* `cmd`
* `cmd parent`
* `cmd parent one`
* `cmd parent two`

Running `cmd --help` would show the complete list, which is probably not the expected behavior, especially as the list of commands grows.

This PR changes the behavior so that only the next level of subcommands is displayed.
* Running `cmd --help` will only show `cmd parent` as an available command.
* Running `cmd parent --help` will only show `cmd parent one` and `cmd parent two` as available subcommands.