### PR TITLE
fix: do not mutate process.argv

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,8 @@ class Sade {
 		return this;
 	}
 
-	parse(arr, opts={}) {
+	parse(processArgv, opts={}) {
+		let arr = processArgv.slice(); // DON'T mutate process.argv, clone first
 		let offset=2, tmp, idx, isVoid, cmd;
 		let alias = { h:'help', v:'version' };
 		let argv = mri(arr.slice(offset), { alias });

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,8 +105,8 @@ class Sade {
 		return this;
 	}
 
-	parse(processArgv, opts={}) {
-		let arr = processArgv.slice(); // DON'T mutate process.argv, clone first
+	parse(arr, opts={}) {
+		arr = arr.slice(); // copy
 		let offset=2, tmp, idx, isVoid, cmd;
 		let alias = { h:'help', v:'version' };
 		let argv = mri(arr.slice(offset), { alias });

--- a/test/index.js
+++ b/test/index.js
@@ -212,18 +212,68 @@ test('prog.action (multi optional)', t => {
 	(c=true) && run(); // +4 tests
 });
 
-test('prog.parse', t => {
-	t.plan(1);
+test('prog.parse :: safe :: default', t => {
+	let ctx = sade('foo').command('build', '', { default: true });
 
-	let ctx = sade('foo')
-		.command('build')
-		.action(() => {});
+	let argv1 = ['', '', 'build'];
+	let foo = ctx.parse(argv1, { lazy: true });
+	t.deepEqual(argv1, ['', '', 'build'], '~> argv unchanged');
+	t.deepEqual(foo.args, [{ _: [] }], '~> args correct');
 
-	let args = ['', '', 'build'];
-	let argsCopy = args.slice();
-	ctx.parse(argsCopy);
+	let argv2 = ['', ''];
+	let bar = ctx.parse(argv2, { lazy: true });
+	t.deepEqual(argv2, ['', ''], '~> argv unchanged');
+	t.deepEqual(bar.args, [{ _: [] }], '~> args correct');
 
-	t.deepEqual(argsCopy, args, '~> process.argv is not mutated');
+	t.end();
+});
+
+test('prog.parse :: safe :: alias', t => {
+	let ctx = sade('foo').command('build').alias('b');
+
+	let argv1 = ['', '', 'build'];
+	let foo = ctx.parse(argv1, { lazy: true });
+	t.deepEqual(argv1, ['', '', 'build'], '~> argv unchanged');
+	t.deepEqual(foo.args, [{ _: [] }], '~> args correct');
+
+	let argv2 = ['', '', 'b'];
+	let bar = ctx.parse(argv2, { lazy: true });
+	t.deepEqual(argv2, ['', '', 'b'], '~> argv unchanged');
+	t.deepEqual(bar.args, [{ _: [] }], '~> args correct');
+
+	t.end();
+});
+
+test('prog.parse :: safe :: default :: flags', t => {
+	let ctx = sade('foo').command('build <dir>', '', { default: true });
+
+	let argv1 = ['', '', '-r', 'dotenv', 'build', 'public', '--fresh'];
+	let foo = ctx.parse(argv1, { lazy: true });
+	t.deepEqual(argv1, ['', '', '-r', 'dotenv', 'build', 'public', '--fresh'], '~> argv unchanged');
+	t.deepEqual(foo.args, ['public', { _: [], r: 'dotenv', fresh: true }], '~> args correct');
+
+	let argv2 = ['', '', '-r', 'dotenv', 'public', '--fresh'];
+	let bar = ctx.parse(argv2, { lazy: true });
+	t.deepEqual(argv2, ['', '', '-r', 'dotenv', 'public', '--fresh'], '~> argv unchanged');
+	t.deepEqual(bar.args, ['public', { _: [], r: 'dotenv', fresh: true }], '~> args correct');
+
+	t.end();
+});
+
+test('prog.parse :: safe :: alias :: flags', t => {
+	let ctx = sade('foo').command('build <dir>').alias('b');
+
+	let argv1 = ['', '', '-r', 'dotenv', 'build', 'public', '--fresh'];
+	let foo = ctx.parse(argv1, { lazy: true });
+	t.deepEqual(argv1, ['', '', '-r', 'dotenv', 'build', 'public', '--fresh'], '~> argv unchanged');
+	t.deepEqual(foo.args, ['public', { _: [], r: 'dotenv', fresh: true }], '~> args correct');
+
+	let argv2 = ['', '', '-r', 'dotenv', 'b', 'public', '--fresh'];
+	let bar = ctx.parse(argv2, { lazy: true });
+	t.deepEqual(argv2, ['', '', '-r', 'dotenv', 'b', 'public', '--fresh'], '~> argv unchanged');
+	t.deepEqual(bar.args, ['public', { _: [], r: 'dotenv', fresh: true }], '~> args correct');
+
+	t.end();
 });
 
 test('prog.parse :: lazy', t => {

--- a/test/index.js
+++ b/test/index.js
@@ -212,6 +212,20 @@ test('prog.action (multi optional)', t => {
 	(c=true) && run(); // +4 tests
 });
 
+test('prog.parse', t => {
+	t.plan(1);
+
+	let ctx = sade('foo')
+		.command('build')
+		.action(() => {});
+
+	let args = ['', '', 'build'];
+	let argsCopy = args.slice();
+	ctx.parse(argsCopy);
+
+	t.deepEqual(argsCopy, args, '~> process.argv is not mutated');
+});
+
 test('prog.parse :: lazy', t => {
 	t.plan(14);
 


### PR DESCRIPTION
- 1.7.1 introduced some arr.splice's into the code, which caused
  mutations in process.argv, affecting downstream code

- set arr to a clone of process.argv instead so it can be freely
  mutated after
- explicitly call the parameter processArgv so code is written more
  carefully when dealing with it
- add a test to ensure process.argv is not mutated

<hr>

Hi @lukeed -- I'm writing this as **URGENT** as it would appear some code in 1.7.1 was introduced that mutated `process.argv`, which is causing issues downstream, see  https://github.com/jaredpalmer/tsdx/issues/511#issuecomment-586645412 , https://github.com/agilgur5/jest-without-globals/pull/2#issuecomment-586419929 .

Note that the test I added fails on 1.7.1 and 1.7.2. The Usage docs also say to pass `process.argv` _directly_ to `parse` (_not_ a clone), so internal usage should be very careful when using it.

Could we get this merged and published **ASAP** before it affects more code downstream?
It causes some _extremely_ confusing errors and it was _very_ time-consuming for me to figure out what was happening and where it was coming from 😕 