### PR TITLE
Fix invalid URI in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": {
     "name": "Luke Edwards",
     "email": "luke.edwards05@gmail.com",
-    "url": "lukeed.com"
+    "url": "https://lukeed.com"
   },
   "scripts": {
     "test": "tape test/*.js | tap-spec"


### PR DESCRIPTION
A URI must start with a protocol to be valid.