### PR TITLE
chore: add `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,14 @@
     "build": "rollup -c",
     "test": "tape -r esm test/*.js | tap-spec"
   },
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "module-sync": "./lib/index.mjs",
+      "require": "./lib/index.js",
+      "default": "./lib/index.mjs"
+    }
+  },
   "dependencies": {
     "mri": "^1.1.0"
   },


### PR DESCRIPTION
Leaving the `main` and `module` for now for backwards compatibility. Those could potentially be dropped with the next major